### PR TITLE
Simplify equation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ class Master {
     );
 
     const x = this.Data.Level;
-    const equation = x * 250 + x * 250 + x * 250;
+    const equation = x * 750;
     while (this.Data.Experience >= equation) {
       this.Data.Level++;
       this.Data.Experience -= equation;


### PR DESCRIPTION
On line 27, `equation` is defined as this:
`    const equation = x * 250 + x * 250 + x * 250;`
... Why? It's the same as `x * 750`:
`    const equation = x * 750;`
Please tell me if I'm just dumb :/